### PR TITLE
[volume-1] 회원가입, 로그인 구현

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/user/UserFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/user/UserFacade.java
@@ -1,0 +1,50 @@
+package com.loopers.application.user;
+
+import com.loopers.domain.user.User;
+import com.loopers.domain.user.UserCommand;
+import com.loopers.domain.user.UserCommand.Create;
+import com.loopers.domain.user.UserService;
+import com.loopers.support.error.user.UserAlreadyExistsException;
+import com.loopers.support.error.user.UserNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Component
+public class UserFacade {
+
+    private final UserService userService;
+
+    public UserInfo signUp(UserCommand.Create command) {
+        validateDuplicateUserId(command);
+        User savedUser = userService.create(command);
+        return UserInfo.from(savedUser);
+    }
+
+    @Transactional
+    public UserPointInfo chargePoint(String userId, Long amount) {
+        User user = userService.findByUserId(userId).orElseThrow(UserNotFoundException::new);
+        user.chargePoint(amount);
+        return UserPointInfo.from(user);
+    }
+
+    public UserInfo getUser(String userId) {
+        return userService.findByUserId(userId)
+            .map(UserInfo::from)
+            .orElseThrow(UserNotFoundException::new);
+    }
+
+    public UserPointInfo getUserPoint(String userId) {
+        return userService.findByUserId(userId)
+            .map(UserPointInfo::from)
+            .orElseThrow(UserNotFoundException::new);
+    }
+
+    private void validateDuplicateUserId(Create command) {
+        userService.findByUserId(command.userId())
+            .ifPresent(user -> {
+                throw new UserAlreadyExistsException();
+            });
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/user/UserInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/user/UserInfo.java
@@ -1,0 +1,27 @@
+package com.loopers.application.user;
+
+import com.loopers.domain.user.User;
+import com.loopers.domain.user.User.Gender;
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record UserInfo(
+    String userId,
+    String email,
+    String birth,
+    Gender gender
+) {
+
+    public static UserInfo from(User user) {
+        Objects.requireNonNull(user, "User 객체가 null입니다.");
+
+        return UserInfo.builder()
+            .userId(user.getUserId())
+            .email(user.getEmail())
+            .birth(user.getBirth())
+            .gender(user.getGender())
+            .build();
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/user/UserPointInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/user/UserPointInfo.java
@@ -1,0 +1,20 @@
+package com.loopers.application.user;
+
+import com.loopers.domain.user.User;
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record UserPointInfo(
+    Long point
+) {
+
+    public static UserPointInfo from(User user) {
+        Objects.requireNonNull(user, "User 객체가 null입니다.");
+
+        return UserPointInfo.builder()
+            .point(user.getPoint())
+            .build();
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java
@@ -1,0 +1,147 @@
+package com.loopers.domain.user;
+
+import com.loopers.domain.BaseEntity;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import com.loopers.support.error.user.PointException;
+import com.loopers.support.error.user.UserErrorType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+import java.util.regex.Pattern;
+import lombok.Getter;
+
+@Getter
+@Entity
+@Table(name = "members")
+public class User extends BaseEntity {
+
+    @Column(
+        name = "user_id",
+        unique = true,
+        nullable = false
+    )
+    private String userId;
+
+    @Column(
+        name = "email",
+        unique = true,
+        nullable = false
+    )
+    private String email;
+
+    @Column(
+        name = "birth",
+        nullable = false
+    )
+    private String birth;
+
+    @Enumerated(EnumType.STRING)
+    @Column(
+        name = "gender"
+    )
+    private Gender gender;
+
+    @Column(
+        name = "point",
+        nullable = false
+    )
+    private Long point;
+
+    protected User() {
+
+    }
+
+    private User(String userId, String email, String birth, Gender gender, Long point) {
+        this.userId = userId;
+        this.email = email;
+        this.birth = birth;
+        this.gender = gender;
+        this.point = point;
+    }
+
+    public static User of(UserCommand.Create command) {
+        validate(command);
+        return new User(command.userId(), command.email(), command.birth(), command.gender(), 0L);
+    }
+
+    public void chargePoint(Long amount) {
+        if(amount == null || amount <= 0) {
+            throw new PointException(UserErrorType.INVALID_CHARGE_AMOUNT);
+        }
+        this.point += amount;
+    }
+
+    private static void validate(UserCommand.Create command) {
+        Validator.userId(command.userId());
+        Validator.email(command.email());
+        Validator.birth(command.birth());
+        Validator.gender(command.gender());
+    }
+
+    private static class Validator {
+
+        private static final Pattern USER_ID_REGEX = Pattern.compile("^[a-zA-Z0-9]{1,10}$");
+        private static final Pattern EMAIL_REGEX = Pattern.compile(
+            "^[a-zA-Z0-9](?:[a-zA-Z0-9_-]*[a-zA-Z0-9]|[a-zA-Z0-9_-]*\\.[a-zA-Z0-9](?:[a-zA-Z0-9_-]*[a-zA-Z0-9])*)*@[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9]|[a-zA-Z0-9-]*\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])*)*\\.[a-zA-Z]{2,6}$"
+        );
+        private static final Pattern BIRTH_REGEX = Pattern.compile("^\\d{4}-\\d{2}-\\d{2}$");
+
+        private Validator() {
+        }
+
+        public static void userId(String userId) {
+            if (isNullOrBlank(userId) ||
+                !USER_ID_REGEX.matcher(userId).matches()) {
+                throw new CoreException(ErrorType.INVALID_INPUT);
+            }
+        }
+
+        public static void email(String email) {
+            if (isNullOrBlank(email) ||
+                !EMAIL_REGEX.matcher(email).matches()
+            ) {
+                throw new CoreException(ErrorType.INVALID_INPUT);
+            }
+        }
+
+        public static void birth(String birth) {
+            validateBirthFormat(birth);
+            validateBirthDate(birth);
+        }
+
+        public static void gender(Gender gender) {
+            if (gender == null) {
+                throw new CoreException(ErrorType.INVALID_INPUT);
+            }
+        }
+
+        private static boolean isNullOrBlank(String value) {
+            return value == null || value.isBlank();
+        }
+
+        private static void validateBirthFormat(String birth) {
+            if (isNullOrBlank(birth) ||
+                !BIRTH_REGEX.matcher(birth).matches()
+            ) {
+                throw new CoreException(ErrorType.INVALID_INPUT);
+            }
+        }
+
+        private static void validateBirthDate(String birth) {
+            try {
+                LocalDate.parse(birth);
+            } catch (DateTimeParseException e) {
+                throw new CoreException(ErrorType.INVALID_INPUT);
+            }
+        }
+    }
+
+    public enum Gender {
+        M, F;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserCommand.java
@@ -1,0 +1,13 @@
+package com.loopers.domain.user;
+
+import com.loopers.domain.user.User.Gender;
+import lombok.Builder;
+
+public class UserCommand {
+
+    @Builder
+    public record Create(String userId, String email, String birth, Gender gender) {
+
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserRepository.java
@@ -1,0 +1,10 @@
+package com.loopers.domain.user;
+
+import java.util.Optional;
+
+public interface UserRepository {
+
+    User save(User user);
+
+    Optional<User> findByUserId(String userId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
@@ -1,0 +1,24 @@
+package com.loopers.domain.user;
+
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public User create(UserCommand.Create command) {
+        User user = User.of(command);
+        return userRepository.save(user);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<User> findByUserId(String userId) {
+        return userRepository.findByUserId(userId);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserJpaRepository.java
@@ -1,0 +1,10 @@
+package com.loopers.infrastructure.user;
+
+import com.loopers.domain.user.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserJpaRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByUserId(String userId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserRepositoryImpl.java
@@ -1,0 +1,24 @@
+package com.loopers.infrastructure.user;
+
+import com.loopers.domain.user.User;
+import com.loopers.domain.user.UserRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+class UserRepositoryImpl implements UserRepository {
+
+    private final UserJpaRepository userJpaRepository;
+
+    @Override
+    public User save(User user) {
+        return userJpaRepository.save(user);
+    }
+    
+    @Override
+    public Optional<User> findByUserId(String userId) {
+        return userJpaRepository.findByUserId(userId);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ApiHeaders.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ApiHeaders.java
@@ -1,0 +1,5 @@
+package com.loopers.interfaces.api;
+
+public class ApiHeaders {
+    public static final String USER_ID = "X-USER-ID";
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1ApiSpec.java
@@ -1,0 +1,53 @@
+package com.loopers.interfaces.api.point;
+
+import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.interfaces.api.point.PointV1Dto.ChargeRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Point V1 API", description = "포인트 관리 API 입니다.")
+public interface PointV1ApiSpec {
+
+    @Operation(
+        summary = "포인트 조회",
+        description = "헤더의 회원 ID로 포인트 정보를 조회합니다."
+    )
+    @Parameter(
+        name = "X-USER-ID",
+        description = "조회할 회원의 ID",
+        required = true,
+        in = ParameterIn.HEADER,
+        schema = @Schema(
+            type = "string",
+            example = "user123"
+        )
+    )
+    ApiResponse<PointV1Dto.PointResponse> getPoint(
+        @Parameter(hidden = true)
+        String userId
+    );
+
+    @Operation(
+        summary = "포인트 충전",
+        description = "헤더의 회원 ID로 포인트를 충전합니다."
+    )
+    @Parameter(
+        name = "X-USER-ID",
+        description = "조회할 회원의 ID",
+        required = true,
+        in = ParameterIn.HEADER,
+        schema = @Schema(
+            type = "string",
+            example = "user123"
+        )
+    )
+    ApiResponse<PointV1Dto.PointResponse> chargePoint(
+        @Parameter(hidden = true)
+        String userId,
+        @Schema(name = "포인트 충전 요청", description = "포인트")
+        PointV1Dto.ChargeRequest request
+    );
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Controller.java
@@ -1,0 +1,37 @@
+package com.loopers.interfaces.api.point;
+
+import com.loopers.application.user.UserFacade;
+import com.loopers.application.user.UserPointInfo;
+import com.loopers.interfaces.api.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/points")
+public class PointV1Controller implements PointV1ApiSpec {
+
+    private final UserFacade userFacade;
+
+    @GetMapping
+    @Override
+    public ApiResponse<PointV1Dto.PointResponse> getPoint(@RequestHeader("X-USER-ID") String userId) {
+        UserPointInfo userPointInfo = userFacade.getUserPoint(userId);
+        return ApiResponse.success(PointV1Dto.PointResponse.from(userPointInfo));
+    }
+
+    @PostMapping("/charge")
+    @Override
+    public ApiResponse<PointV1Dto.PointResponse> chargePoint(
+        @RequestHeader("X-USER-ID") String userId,
+        @RequestBody PointV1Dto.ChargeRequest request
+    ) {
+        UserPointInfo userPointInfo = userFacade.chargePoint(userId, request.amount());
+        return ApiResponse.success(PointV1Dto.PointResponse.from(userPointInfo));
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Dto.java
@@ -1,0 +1,29 @@
+package com.loopers.interfaces.api.point;
+
+import com.loopers.application.user.UserPointInfo;
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+public class PointV1Dto {
+
+    @Builder
+    public record ChargeRequest(
+        Long amount
+    ) {
+
+    }
+
+    @Builder(access = AccessLevel.PRIVATE)
+    public record PointResponse(
+        Long point
+    ) {
+        public static PointResponse from(UserPointInfo userPointInfo) {
+            Objects.requireNonNull(userPointInfo, "UserPointInfo 객체가 null입니다.");
+
+            return PointResponse.builder()
+                .point(userPointInfo.point())
+                .build();
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
@@ -1,0 +1,40 @@
+package com.loopers.interfaces.api.user;
+
+import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "User V1 API", description = "회원 관리 API 입니다.")
+public interface UserV1ApiSpec {
+
+    @Operation(
+        summary = "회원 가입",
+        description = "새로운 회원을 등록합니다."
+    )
+    ApiResponse<UserV1Dto.UserResponse> signUp(
+        @Schema(name = "회원 가입 요청", description = "가입할 회원의 정보")
+        UserV1Dto.SignUpRequest request
+    );
+
+    @Operation(
+        summary = "회원 조회",
+        description = "ID로 회원 정보를 조회합니다."
+    )
+    @Parameter(
+        name = "X-USER-ID",
+        description = "조회할 회원의 ID",
+        required = true,
+        in = ParameterIn.HEADER,
+        schema = @Schema(
+            type = "string",
+            example = "user123"
+        )
+    )
+    ApiResponse<UserV1Dto.UserResponse> getUser(
+        @Parameter(hidden = true)
+        String userId
+    );
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
@@ -1,0 +1,39 @@
+package com.loopers.interfaces.api.user;
+
+import com.loopers.application.user.UserFacade;
+import com.loopers.application.user.UserInfo;
+import com.loopers.domain.user.UserCommand;
+import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.interfaces.api.user.UserV1Dto.SignUpRequest;
+import com.loopers.interfaces.api.user.UserV1Dto.UserResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/users")
+public class UserV1Controller implements UserV1ApiSpec {
+
+    private final UserFacade userFacade;
+
+    @PostMapping
+    @Override
+    public ApiResponse<UserResponse> signUp(@Valid @RequestBody SignUpRequest request) {
+        UserCommand.Create command = request.toCommand();
+        UserInfo userInfo = userFacade.signUp(command);
+        return ApiResponse.success(UserResponse.from(userInfo));
+    }
+
+    @GetMapping("/me")
+    @Override
+    public ApiResponse<UserResponse> getUser(@RequestHeader("X-USER-ID") String userId) {
+        UserInfo userInfo = userFacade.getUser(userId);
+        return ApiResponse.success(UserResponse.from(userInfo));
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Dto.java
@@ -1,0 +1,65 @@
+package com.loopers.interfaces.api.user;
+
+import com.loopers.application.user.UserInfo;
+import com.loopers.domain.user.User;
+import com.loopers.domain.user.User.Gender;
+import com.loopers.domain.user.UserCommand;
+import jakarta.validation.constraints.NotNull;
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+public class UserV1Dto {
+
+    @Builder
+    public record SignUpRequest(
+        String userId,
+        String email,
+        String birth,
+        @NotNull GenderRequest gender
+    ) {
+        public UserCommand.Create toCommand() {
+            return UserCommand.Create.builder()
+                .userId(userId)
+                .email(email)
+                .birth(birth)
+                .gender(gender.toDomain())
+                .build();
+        }
+
+        public enum GenderRequest {
+            M, F;
+
+            public User.Gender toDomain() {
+                return User.Gender.valueOf(this.name());
+            }
+        }
+    }
+
+    @Builder(access = AccessLevel.PRIVATE)
+    public record UserResponse(
+        String userId,
+        String email,
+        String birth,
+        GenderResponse gender
+    ) {
+        public static UserResponse from(UserInfo userInfo) {
+            Objects.requireNonNull(userInfo, "UserInfo 객체가 null입니다.");
+
+            return UserResponse.builder()
+                .userId(userInfo.userId())
+                .email(userInfo.email())
+                .birth(userInfo.birth())
+                .gender(GenderResponse.toResponse(userInfo.gender()))
+                .build();
+        }
+
+        public enum GenderResponse {
+            M, F;
+
+            public static GenderResponse toResponse(Gender gender) {
+                return GenderResponse.valueOf(gender.name());
+            }
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/support/error/CoreException.java
+++ b/apps/commerce-api/src/main/java/com/loopers/support/error/CoreException.java
@@ -4,16 +4,16 @@ import lombok.Getter;
 
 @Getter
 public class CoreException extends RuntimeException {
-    private final ErrorType errorType;
+    private final ErrorCode errorCode;
     private final String customMessage;
 
-    public CoreException(ErrorType errorType) {
-        this(errorType, null);
+    public CoreException(ErrorCode errorCode) {
+        this(errorCode, null);
     }
 
-    public CoreException(ErrorType errorType, String customMessage) {
-        super(customMessage != null ? customMessage : errorType.getMessage());
-        this.errorType = errorType;
+    public CoreException(ErrorCode errorCode, String customMessage) {
+        super(customMessage != null ? customMessage : errorCode.getMessage());
+        this.errorCode = errorCode;
         this.customMessage = customMessage;
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/support/error/ErrorCode.java
+++ b/apps/commerce-api/src/main/java/com/loopers/support/error/ErrorCode.java
@@ -1,0 +1,12 @@
+package com.loopers.support.error;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+
+    HttpStatus getStatus();
+
+    String getMessage();
+
+    String getCode();
+}

--- a/apps/commerce-api/src/main/java/com/loopers/support/error/ErrorType.java
+++ b/apps/commerce-api/src/main/java/com/loopers/support/error/ErrorType.java
@@ -6,12 +6,15 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
-public enum ErrorType {
+public enum ErrorType implements ErrorCode {
     /** 범용 에러 */
     INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase(), "일시적인 오류가 발생했습니다."),
     BAD_REQUEST(HttpStatus.BAD_REQUEST, HttpStatus.BAD_REQUEST.getReasonPhrase(), "잘못된 요청입니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, HttpStatus.NOT_FOUND.getReasonPhrase(), "존재하지 않는 요청입니다."),
-    CONFLICT(HttpStatus.CONFLICT, HttpStatus.CONFLICT.getReasonPhrase(), "이미 존재하는 리소스입니다.");
+    CONFLICT(HttpStatus.CONFLICT, HttpStatus.CONFLICT.getReasonPhrase(), "이미 존재하는 리소스입니다."),
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, HttpStatus.CONFLICT.getReasonPhrase(), "입력값이 올바르지 않습니다."),
+    MISSING_REQUEST_HEADER(HttpStatus.BAD_REQUEST, HttpStatus.BAD_REQUEST.getReasonPhrase(), "필수 헤더가 누락되었습니다."),
+    ;
 
     private final HttpStatus status;
     private final String code;

--- a/apps/commerce-api/src/main/java/com/loopers/support/error/user/PointException.java
+++ b/apps/commerce-api/src/main/java/com/loopers/support/error/user/PointException.java
@@ -1,0 +1,8 @@
+package com.loopers.support.error.user;
+
+public class PointException extends UserException {
+
+    public PointException(UserErrorType errorType) {
+        super(errorType);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/support/error/user/UserAlreadyExistsException.java
+++ b/apps/commerce-api/src/main/java/com/loopers/support/error/user/UserAlreadyExistsException.java
@@ -1,0 +1,10 @@
+package com.loopers.support.error.user;
+
+import com.loopers.support.error.ErrorType;
+
+public class UserAlreadyExistsException extends UserException {
+
+    public UserAlreadyExistsException() {
+        super(ErrorType.CONFLICT);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/support/error/user/UserErrorType.java
+++ b/apps/commerce-api/src/main/java/com/loopers/support/error/user/UserErrorType.java
@@ -1,0 +1,17 @@
+package com.loopers.support.error.user;
+
+import com.loopers.support.error.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserErrorType implements ErrorCode {
+    INVALID_CHARGE_AMOUNT(HttpStatus.BAD_REQUEST, HttpStatus.BAD_REQUEST.getReasonPhrase(), "포인트 충전 금액이 올바르지 않습니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/apps/commerce-api/src/main/java/com/loopers/support/error/user/UserException.java
+++ b/apps/commerce-api/src/main/java/com/loopers/support/error/user/UserException.java
@@ -1,0 +1,15 @@
+package com.loopers.support.error.user;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorCode;
+
+public class UserException extends CoreException {
+
+    public UserException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public UserException(ErrorCode errorCode, String customMessage) {
+        super(errorCode, customMessage);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/support/error/user/UserNotFoundException.java
+++ b/apps/commerce-api/src/main/java/com/loopers/support/error/user/UserNotFoundException.java
@@ -1,0 +1,10 @@
+package com.loopers.support.error.user;
+
+import com.loopers.support.error.ErrorType;
+
+public class UserNotFoundException extends UserException {
+
+    public UserNotFoundException() {
+        super(ErrorType.NOT_FOUND);
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/application/user/UserFacadeIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/user/UserFacadeIntegrationTest.java
@@ -1,0 +1,173 @@
+package com.loopers.application.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.field;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.loopers.domain.user.User;
+import com.loopers.domain.user.UserCommand;
+import com.loopers.domain.user.UserService;
+import com.loopers.domain.user.fixture.UserCommandFixture;
+import com.loopers.support.error.ErrorType;
+import com.loopers.support.error.user.UserAlreadyExistsException;
+import com.loopers.support.error.user.UserNotFoundException;
+import com.loopers.testcontainers.MySqlTestContainersConfig;
+import com.loopers.utils.DatabaseCleanUp;
+import org.instancio.Instancio;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@Import(MySqlTestContainersConfig.class)
+class UserFacadeIntegrationTest {
+
+    @Autowired
+    private UserFacade userFacade;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @MockitoSpyBean
+    private UserService userService;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @DisplayName("회원 가입 시, ")
+    @Nested
+    class SignUp {
+
+        @DisplayName("이미 가입된 ID 로 회원가입 시도 시, 실패한다.")
+        @Test
+        void throwsException_whenUserIdDuplicate() {
+            // arrange
+            String duplicateUserId = "testUser";
+            UserCommand.Create command = UserCommandFixture.Create.complete()
+                .set(field(UserCommand.Create::userId), duplicateUserId)
+                .create();
+            userFacade.signUp(command);
+
+            // act
+            UserAlreadyExistsException exception =
+                assertThrows(UserAlreadyExistsException.class, () -> userFacade.signUp(command));
+
+            // assert
+            assertThat(exception.getErrorCode()).isEqualTo(ErrorType.CONFLICT);
+        }
+
+        @DisplayName("정상적인 회원 데이터인 경우, 회원가입에 성공한다.")
+        @Test
+        void doesNotThrow_whenValidUserData() {
+            // arrange
+            UserCommand.Create command = UserCommandFixture.Create.complete().create();
+
+            // act
+            UserInfo userInfo = userFacade.signUp(command);
+
+            // assert
+            assertThat(userInfo).isNotNull();
+            assertThat(userInfo.userId()).isEqualTo(command.userId());
+            assertThat(userInfo.gender()).isEqualTo(command.gender());
+            assertThat(userInfo.birth()).isEqualTo(command.birth());
+            assertThat(userInfo.email()).isEqualTo(command.email());
+        }
+    }
+
+    @DisplayName("회원 조회 시, ")
+    @Nested
+    class Get {
+
+        @DisplayName("해당 ID 의 회원이 존재할 경우, 회원 정보가 반환된다.")
+        @Test
+        void returnsUserInfo_whenValidIdIsProvided() {
+            // arrange
+            UserCommand.Create command = UserCommandFixture.Create.complete().create();
+            UserInfo savedUserInfo = userFacade.signUp(command);
+
+            // act
+            UserInfo findUserInfo = userFacade.getUser(savedUserInfo.userId());
+
+            // assert
+            assertThat(findUserInfo).isNotNull();
+            assertThat(findUserInfo.userId()).isEqualTo(savedUserInfo.userId());
+            assertThat(findUserInfo.birth()).isEqualTo(savedUserInfo.birth());
+            assertThat(findUserInfo.gender()).isEqualTo(savedUserInfo.gender());
+        }
+
+        @DisplayName("해당 ID 의 회원이 존재하지 않을 경우, UserNotFoundException 예외를 던진다.")
+        @Test
+        void throwsUserNotFoundException_whenGetUserWithNonExistentId() {
+            // arrange
+            String randomUserId = Instancio.create(String.class);
+
+            // act
+            UserNotFoundException exception =
+                assertThrows(UserNotFoundException.class, () -> userFacade.getUser(randomUserId));
+
+            // assert
+            assertThat(exception.getErrorCode()).isEqualTo(ErrorType.NOT_FOUND);
+        }
+
+        @DisplayName("해당 ID 의 회원이 존재할 경우, 보유 포인트가 반환된다.")
+        @Test
+        void returnsUserPoint_whenValidIdIsProvided() {
+            // arrange
+            UserCommand.Create command = UserCommandFixture.Create.complete().create();
+            UserInfo savedUserInfo = userFacade.signUp(command);
+
+            // act
+            UserPointInfo findUserInfo = userFacade.getUserPoint(savedUserInfo.userId());
+
+            // assert
+            assertThat(findUserInfo).isNotNull();
+            assertThat(findUserInfo.point()).isZero();
+        }
+    }
+
+    @DisplayName("포인트 충전 시, ")
+    @Nested
+    class PointCharge {
+
+        @DisplayName("해당 ID 의 회원이 존재하지 않을 경우, UserNotFoundException 예외를 반환된다.")
+        @Test
+        void throwsUserNotFoundException_whenChargePointWithNonExistentId() {
+            // arrange
+            String randomId = Instancio.create(String.class);
+            Long amount = 100L;
+
+            // act
+            UserNotFoundException exception =
+                assertThrows(UserNotFoundException.class, () -> userFacade.chargePoint(randomId, amount));
+
+            // assert
+            assertThat(exception.getErrorCode()).isEqualTo(ErrorType.NOT_FOUND);
+        }
+
+        @DisplayName("해당 ID 의 회원이 존재할 경우, 총 보유 포인트가 반환된다.")
+        @Test
+        void returnUserPointInfo_whenValidIdIsProvided() {
+            // arrange
+            UserCommand.Create command = UserCommandFixture.Create.complete().create();
+            User savedUser = userService.create(command);
+            Long chargeAmount = 1000L;
+
+            // act
+            UserPointInfo userPointInfo = userFacade.chargePoint(savedUser.getUserId(), chargeAmount);
+
+            // assert
+            assertThat(userPointInfo).isNotNull();
+            assertThat(userPointInfo.point()).isEqualTo(chargeAmount);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/example/ExampleModelTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/example/ExampleModelTest.java
@@ -44,7 +44,7 @@ class ExampleModelTest {
             });
 
             // assert
-            assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+            assertThat(result.getErrorCode()).isEqualTo(ErrorType.BAD_REQUEST);
         }
 
         @DisplayName("설명이 비어있으면, BAD_REQUEST 예외가 발생한다.")
@@ -59,7 +59,7 @@ class ExampleModelTest {
             });
 
             // assert
-            assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+            assertThat(result.getErrorCode()).isEqualTo(ErrorType.BAD_REQUEST);
         }
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/example/ExampleServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/example/ExampleServiceIntegrationTest.java
@@ -66,7 +66,7 @@ class ExampleServiceIntegrationTest {
             });
 
             // assert
-            assertThat(exception.getErrorType()).isEqualTo(ErrorType.NOT_FOUND);
+            assertThat(exception.getErrorCode()).isEqualTo(ErrorType.NOT_FOUND);
         }
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceTest.java
@@ -1,0 +1,89 @@
+package com.loopers.domain.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+
+import com.loopers.domain.user.fixture.UserCommandFixture;
+import java.util.Optional;
+import org.instancio.Instancio;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+public class UserServiceTest {
+
+    @Autowired
+    private UserService userService;
+
+    @MockitoSpyBean
+    private UserRepository userRepository;
+
+    @DisplayName("회원 서비스에서,")
+    @Nested
+    class Create {
+
+        @DisplayName("회원 도메인 객체 생성 후 User 저장이 수행된다. ( spy 검증 )")
+        @RepeatedTest(10)
+        void returnsUser_whenCreateUser() {
+            // arrange
+            UserCommand.Create command = UserCommandFixture.Create.complete().create();
+            User expectedUser = User.of(command);
+            doReturn(expectedUser).when(userRepository).save(any(User.class));
+
+            // act
+            User savedUser = userService.create(command);
+
+            // assert
+            assertUserEquals(savedUser, expectedUser);
+        }
+    }
+
+    @DisplayName("회원 서비스에서, ")
+    @Nested
+    class Read {
+
+        @DisplayName("해당 ID 의 회원이 존재할 경우, 회원 정보가 반환된다.")
+        @Test
+        void returnsUser_whenValidIdIsProvided() {
+            // arrange
+            UserCommand.Create command = UserCommandFixture.Create.complete().create();
+            User savedUser = userService.create(command);
+
+            // act
+            Optional<User> optionalUser = userService.findByUserId(savedUser.getUserId());
+
+            // assert
+            assertThat(optionalUser).isPresent();
+            User foundUser = optionalUser.get();
+            assertUserEquals(foundUser, savedUser);
+        }
+
+        @DisplayName("해당 ID 의 회원이 존재하지 않을 경우, null 이 반환된다.")
+        @Test
+        void returnNull_whenInValidIdIsProvided() {
+            // arrange
+            String randomUserId = Instancio.create(String.class);
+
+            // act
+            Optional<User> optionalUser = userService.findByUserId(randomUserId);
+
+            // assert
+            assertThat(optionalUser).isNotPresent();
+        }
+    }
+
+    private void assertUserEquals(User actual, User expected) {
+        assertThat(actual.getId()).isEqualTo(expected.getId());
+        assertThat(actual.getUserId()).isEqualTo(expected.getUserId());
+        assertThat(actual.getBirth()).isEqualTo(expected.getBirth());
+        assertThat(actual.getEmail()).isEqualTo(expected.getEmail());
+        assertThat(actual.getGender()).isEqualTo(expected.getGender());
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserTest.java
@@ -1,0 +1,168 @@
+package com.loopers.domain.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.field;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.loopers.domain.user.User.Gender;
+import com.loopers.domain.user.fixture.UserCommandFixture;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import com.loopers.support.error.user.PointException;
+import com.loopers.support.error.user.UserErrorType;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class UserTest {
+
+    @DisplayName("회원 명령 객체 생성 시,")
+    @Nested
+    class Create {
+
+        @DisplayName("ID 가 `영문 및 숫자 10자 이내` 형식에 맞지 않으면, User 객체 생성에 실패한다.")
+        @ParameterizedTest
+        @NullSource
+        @MethodSource("invalidUserIds")
+        void throwsInvalidException_whenUserIdIsInvalid(String invalidUserId) {
+            // arrange
+            UserCommand.Create command = UserCommandFixture.Create.complete()
+                .set(field(UserCommand.Create::userId), invalidUserId)
+                .create();
+
+            // act
+            CoreException exception = assertThrows(CoreException.class, () -> User.of(command));
+
+            // assert
+            assertThat(exception.getErrorCode()).isEqualTo(ErrorType.INVALID_INPUT);
+        }
+
+        @DisplayName("이메일이 `xx@yy.zz` 형식에 맞지 않으면, User 객체 생성에 실패한다.")
+        @ParameterizedTest
+        @NullSource
+        @MethodSource("invalidEmails")
+        void throwsInvalidException_whenEmailIsInvalid(String invalidEmail) {
+            // arrange
+            UserCommand.Create command = UserCommandFixture.Create.complete()
+                .set(field(UserCommand.Create::email), invalidEmail)
+                .create();
+
+            // act
+            CoreException exception = assertThrows(CoreException.class, () -> User.of(command));
+
+            // assert
+            assertThat(exception.getErrorCode()).isEqualTo(ErrorType.INVALID_INPUT);
+        }
+
+        @DisplayName("생년월일이 `yyyy-MM-dd` 형식에 맞지 않으면, User 객체 생성에 실패한다.")
+        @ParameterizedTest
+        @NullSource
+        @MethodSource("invalidBirths")
+        void throwsInvalidException_whenBirthIsInvalid(String invalidBirth) {
+            // arrange
+            UserCommand.Create command = UserCommandFixture.Create.complete()
+                .set(field(UserCommand.Create::birth), invalidBirth)
+                .create();
+
+            // act
+            CoreException exception = assertThrows(CoreException.class, () -> User.of(command));
+
+            // assert
+            assertThat(exception.getErrorCode()).isEqualTo(ErrorType.INVALID_INPUT);
+        }
+
+        @DisplayName("성별이 없는 경우, User 객체 생성에 실패한다.")
+        @ParameterizedTest
+        @NullSource
+        void throwsInvalidException_whenGenderIsNullAndEmpty(Gender invalidGender) {
+            // arrange
+            UserCommand.Create command = UserCommandFixture.Create.complete()
+                .set(field(UserCommand.Create::gender), invalidGender)
+                .create();
+
+            // act
+            CoreException exception = assertThrows(CoreException.class, () -> User.of(command));
+
+            // assert
+            assertThat(exception.getErrorCode()).isEqualTo(ErrorType.INVALID_INPUT);
+        }
+
+        @DisplayName("0 이하의 정수로 포인트를 충전 시 실패한다.")
+        @ParameterizedTest
+        @NullSource
+        @ValueSource(longs = {0L, -1L, -100L, -999L})
+        void throwsPointException_whenAmountIsZeroOrBelow(Long invalidPoint) {
+            // arrange
+            UserCommand.Create command = UserCommandFixture.Create.complete().create();
+            User user = User.of(command);
+
+            // act
+            PointException exception = assertThrows(PointException.class,
+                () -> user.chargePoint(invalidPoint));
+
+            // assert
+            assertThat(exception.getErrorCode()).isEqualTo(UserErrorType.INVALID_CHARGE_AMOUNT);
+        }
+
+        static Stream<Arguments> invalidUserIds() {
+            return TestDataProvider.invalidUserIds();
+        }
+
+        static Stream<Arguments> invalidEmails() {
+            return TestDataProvider.invalidEmails();
+        }
+
+        static Stream<Arguments> invalidBirths() {
+            return TestDataProvider.invalidBirths();
+        }
+
+        static class TestDataProvider {
+
+            static Stream<Arguments> invalidUserIds() {
+                return Stream.of(
+                    emptyValues(),
+                    args("abcdefghijk", "12345678901", "abc1234567890"),
+                    args("abc@123", "test.user", "user-123", "user_name"),
+                    args("한글abc", "test한글"),
+                    args("test 123", " test123", "test123 ")
+                ).flatMap(stream -> stream);
+            }
+
+            static Stream<Arguments> invalidEmails() {
+                return Stream.of(
+                    emptyValues(),
+                    args("testuser.com", "test@@example.com", "@example.com", "test@"),
+                    args("test@domain", "test@.example.com", "test@example.", "test@example..com"),
+                    args("test user@example.com", "test..user@example.com",
+                        ".testuser@example.com", "test.user.@example.com"),
+                    args("테스트@example.com", "test@한글.com", "test@example.c")
+                ).flatMap(stream -> stream);
+            }
+
+            static Stream<Arguments> invalidBirths() {
+                return Stream.of(
+                    emptyValues(),
+                    args("1990/01/01", "1990.01.01", "19900101", "1990-1-1"),
+                    args("90-01-01", "19900-01-01"),
+                    args("1990-00-01", "1990-13-01", "1990-01-00", "1990-01-32"),
+                    args("1990-02-30", "1990-04-31", "1990-02-29"),
+                    args("abcd-01-01", "1990-ab-01", "1990년-01월-01일"),
+                    args(" 1990-01-01", "1990-01-01 ", "1990 - 01 - 01")
+                ).flatMap(stream -> stream);
+            }
+
+            private static Stream<Arguments> emptyValues() {
+                return Stream.of("", "   ", "    ").map(Arguments::of);
+            }
+
+            private static Stream<Arguments> args(String... values) {
+                return Stream.of(values).map(Arguments::of);
+            }
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/fixture/UserCommandFixture.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/fixture/UserCommandFixture.java
@@ -1,0 +1,29 @@
+package com.loopers.domain.user.fixture;
+
+import static org.instancio.Select.field;
+
+import com.loopers.domain.user.UserCommand;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import org.instancio.Instancio;
+import org.instancio.InstancioApi;
+
+public class UserCommandFixture {
+
+    public static class Create {
+
+        public static InstancioApi<UserCommand.Create> complete() {
+            return Instancio.of(UserCommand.Create.class)
+                .generate(field(UserCommand.Create::userId), gen -> gen.string()
+                    .length(5, 10)
+                    .alphaNumeric()
+                )
+                .generate(field(UserCommand.Create::email), gen -> gen.net().email())
+                .generate(field(UserCommand.Create::birth), gen -> gen.temporal()
+                    .localDate()
+                    .range(LocalDate.of(1950, 1, 1), LocalDate.of(2005, 12, 31))
+                    .as(date -> date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
+                );
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/point/PointV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/point/PointV1ApiE2ETest.java
@@ -1,0 +1,174 @@
+package com.loopers.interfaces.api.point;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.loopers.interfaces.api.ApiHeaders;
+import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.interfaces.api.point.PointV1Dto.PointResponse;
+import com.loopers.interfaces.api.user.UserV1Dto;
+import com.loopers.interfaces.api.user.UserV1Dto.UserResponse;
+import com.loopers.interfaces.api.user.fixture.UserV1DtoFixture;
+import com.loopers.testcontainers.MySqlTestContainersConfig;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@Import(MySqlTestContainersConfig.class)
+class PointV1ApiE2ETest {
+
+    private static final String ENDPOINT = "/api/v1/points";
+
+    private final TestRestTemplate testRestTemplate;
+    private final DatabaseCleanUp databaseCleanUp;
+
+    @Autowired
+    public PointV1ApiE2ETest(
+        TestRestTemplate testRestTemplate,
+        DatabaseCleanUp databaseCleanUp
+    ) {
+        this.testRestTemplate = testRestTemplate;
+        this.databaseCleanUp = databaseCleanUp;
+    }
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @DisplayName("GET /api/v1/points")
+    @Nested
+    class Get {
+
+        @DisplayName("존재하지 않는 ID 로 조회할 경우, `404 Not Found` 응답을 반환한다.")
+        @Test
+        void returns404NotFound_whenUserDoesNotExist() {
+            // arrange
+            String userId = "12345";
+            HttpHeaders headers = new HttpHeaders();
+            headers.set(ApiHeaders.USER_ID, userId);
+
+            // act
+            ParameterizedTypeReference<ApiResponse<UserResponse>> responseType = new ParameterizedTypeReference<>() {
+            };
+            var response =
+                testRestTemplate.exchange(ENDPOINT, HttpMethod.GET, new HttpEntity<>(headers), responseType);
+
+            // assert
+            assertAll(
+                () -> assertTrue(response.getStatusCode().is4xxClientError()),
+                () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND)
+            );
+        }
+
+        @DisplayName("해당 ID 의 회원이 존재할 경우, 보유 포인트를 응답으로 반환한다.")
+        @Test
+        void returnsUserPointResponse_whenUserExist() {
+            // arrange
+            UserV1Dto.SignUpRequest request = UserV1DtoFixture.SignUpRequest.complete().create();
+            String userId = testRestTemplate.exchange("/api/v1/users", HttpMethod.POST, new HttpEntity<>(request), new ParameterizedTypeReference<ApiResponse<UserV1Dto.UserResponse>>() {
+                })
+                .getBody()
+                .data()
+                .userId();
+            HttpHeaders headers = new HttpHeaders();
+            headers.set(ApiHeaders.USER_ID, String.valueOf(userId));
+
+            // act
+            ParameterizedTypeReference<ApiResponse<PointV1Dto.PointResponse>> responseType = new ParameterizedTypeReference<>() {
+            };
+            var response =
+                testRestTemplate.exchange(ENDPOINT, HttpMethod.GET, new HttpEntity<>(headers), responseType);
+
+            // assert
+            assertAll(
+                () -> assertTrue(response.getStatusCode().is2xxSuccessful()),
+                () -> assertThat(response.getBody().data().point()).isZero()
+            );
+        }
+    }
+
+    @DisplayName("POST /api/v1/points")
+    @Nested
+    class Post {
+
+        @DisplayName("존재하지 않는 ID 로 조회할 경우, `404 Not Found` 응답을 반환한다.")
+        @Test
+        void returns404NotFound_whenUserDoesNotExist() {
+            // arrange
+            String userId = "12345";
+            HttpHeaders headers = new HttpHeaders();
+            headers.set(ApiHeaders.USER_ID, userId);
+
+            var chargeAmount = 1000L;
+            var chargePointRequest = PointV1Dto.ChargeRequest.builder()
+                .amount(chargeAmount)
+                .build();
+
+            // act
+            ParameterizedTypeReference<ApiResponse<PointResponse>> responseType = new ParameterizedTypeReference<>() {
+            };
+            var response =
+                testRestTemplate.exchange(ENDPOINT + "/charge", HttpMethod.POST, new HttpEntity<>(chargePointRequest, headers), responseType);
+
+            // assert
+            assertAll(
+                () -> assertTrue(response.getStatusCode().is4xxClientError()),
+                () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND)
+            );
+        }
+
+        @DisplayName("존재하는 유저가 1000원을 충전할 경우, 충전된 보유 총량을 응답으로 반환한다.")
+        @Test
+        void returnUserPointResponse_whenValidUserCharges1000Won() {
+            // arrange
+            var request = UserV1DtoFixture.SignUpRequest.complete().create();
+            var userId = testRestTemplate.exchange("/api/v1/users", HttpMethod.POST, new HttpEntity<>(request), new ParameterizedTypeReference<ApiResponse<UserV1Dto.UserResponse>>() {
+                })
+                .getBody()
+                .data()
+                .userId();
+
+            var chargeAmount = 1000L;
+            var chargePointRequest = PointV1Dto.ChargeRequest.builder()
+                .amount(chargeAmount)
+                .build();
+
+            var headers = new HttpHeaders();
+            headers.set(ApiHeaders.USER_ID, String.valueOf(userId));
+
+            // act
+            var response = testRestTemplate.exchange(
+                ENDPOINT + "/charge",
+                HttpMethod.POST,
+                new HttpEntity<>(chargePointRequest, headers),
+                new ParameterizedTypeReference<ApiResponse<PointV1Dto.PointResponse>>() {
+                },
+                userId
+            );
+
+            // assert
+            assertAll(
+                () -> assertTrue(response.getStatusCode().is2xxSuccessful()),
+                () -> assertThat(response.getBody()).isNotNull(),
+                () -> assertThat(response.getBody().data()).isNotNull(),
+                () -> assertThat(response.getBody().data().point()).isEqualTo(chargeAmount)
+            );
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/user/UserV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/user/UserV1ApiE2ETest.java
@@ -1,0 +1,157 @@
+package com.loopers.interfaces.api.user;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.instancio.Select.field;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.interfaces.api.user.fixture.UserV1DtoFixture;
+import com.loopers.testcontainers.MySqlTestContainersConfig;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@Import(MySqlTestContainersConfig.class)
+class UserV1ApiE2ETest {
+
+    private static final String ENDPOINT = "/api/v1/users";
+
+    private final TestRestTemplate testRestTemplate;
+    private final DatabaseCleanUp databaseCleanUp;
+
+    @Autowired
+    public UserV1ApiE2ETest(
+        TestRestTemplate testRestTemplate,
+        DatabaseCleanUp databaseCleanUp
+    ) {
+        this.testRestTemplate = testRestTemplate;
+        this.databaseCleanUp = databaseCleanUp;
+    }
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @DisplayName("POST /api/v1/users")
+    @Nested
+    class Post {
+
+        @DisplayName("회원 가입이 성공할 경우, 생성된 유저 정보를 응답으로 반환한다.")
+        @Test
+        void returnsUserResponse_whenValidUserData() {
+            // arrange
+            UserV1Dto.SignUpRequest request = UserV1DtoFixture.SignUpRequest.complete().create();
+
+            // act
+            ParameterizedTypeReference<ApiResponse<UserV1Dto.UserResponse>> responseType = new ParameterizedTypeReference<>() {
+            };
+            var response = testRestTemplate.exchange(ENDPOINT, HttpMethod.POST, new HttpEntity<>(request), responseType);
+
+            // assert
+            assertAll(
+                () -> assertTrue(response.getStatusCode().is2xxSuccessful()),
+                () -> assertThat(response.getBody()).isNotNull(),
+                () -> assertThat(response.getBody().data()).isNotNull(),
+                () -> {
+                    var actual = response.getBody().data();
+                    assertThat(actual.userId()).isEqualTo(request.userId());
+                    assertThat(actual.email()).isEqualTo(request.email());
+                    assertThat(actual.birth()).isEqualTo(request.birth());
+                    assertThat(actual.gender().name()).isEqualTo(request.gender().name());
+                }
+            );
+        }
+
+        @DisplayName("회원 가입 시 성별이 없을 경우, 400 Bad Request를 응답한다.")
+        @Test
+        void returnsBadRequest_whenGenderIsMissing() {
+            var request = UserV1DtoFixture.SignUpRequest.complete()
+                .ignore(field(UserV1Dto.SignUpRequest::gender))
+                .create();
+
+            // act
+            ParameterizedTypeReference<ApiResponse<UserV1Dto.UserResponse>> responseType = new ParameterizedTypeReference<>() {
+            };
+            var response = testRestTemplate.exchange(ENDPOINT, HttpMethod.POST, new HttpEntity<>(request), responseType);
+
+            // assert
+            assertAll(() -> assertTrue(response.getStatusCode().is4xxClientError()));
+        }
+    }
+
+    @DisplayName("GET /api/v1/users/{id}")
+    @Nested
+    class GET {
+
+        @DisplayName("존재하지 않는 ID 로 조회할 경우, `404 Not Found` 응답을 반환한다.")
+        @Test
+        void returns404NotFound_whenUserDoesNotExist() {
+            // arrange
+            String userId = "12345";
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("X-USER-ID", userId);
+
+            // act
+            ParameterizedTypeReference<ApiResponse<UserV1Dto.UserResponse>> responseType = new ParameterizedTypeReference<>() {
+            };
+            ResponseEntity<ApiResponse<UserV1Dto.UserResponse>> response =
+                testRestTemplate.exchange(ENDPOINT + "/me", HttpMethod.GET, new HttpEntity<>(headers), responseType);
+
+            // assert
+            assertAll(
+                () -> assertTrue(response.getStatusCode().is4xxClientError())
+            );
+        }
+
+        @DisplayName("내 정보 조회에 성공할 경우, 해당하는 유저 정보를 응답으로 반환한다.")
+        @Test
+        void returnsUserResponse_whenValidIdIsProvided() {
+            // arrange
+            UserV1Dto.SignUpRequest request = UserV1DtoFixture.SignUpRequest.complete().create();
+            String userId = testRestTemplate.exchange(ENDPOINT, HttpMethod.POST, new HttpEntity<>(request), new ParameterizedTypeReference<ApiResponse<UserV1Dto.UserResponse>>() {
+                })
+                .getBody()
+                .data()
+                .userId();
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("X-USER-ID", String.valueOf(userId));
+
+            // act
+            ParameterizedTypeReference<ApiResponse<UserV1Dto.UserResponse>> responseType = new ParameterizedTypeReference<>() {
+            };
+            ResponseEntity<ApiResponse<UserV1Dto.UserResponse>> response =
+                testRestTemplate.exchange(ENDPOINT + "/me", HttpMethod.GET, new HttpEntity<>(headers), responseType);
+
+            // assert
+            assertAll(
+                () -> assertTrue(response.getStatusCode().is2xxSuccessful()),
+                () -> assertThat(response.getBody()).isNotNull(),
+                () -> assertThat(response.getBody().data()).isNotNull(),
+                () -> {
+                    var actual = response.getBody().data();
+                    assertThat(actual.userId()).isEqualTo(request.userId());
+                    assertThat(actual.email()).isEqualTo(request.email());
+                    assertThat(actual.birth()).isEqualTo(request.birth());
+                    assertThat(actual.gender().name()).isEqualTo(request.gender().name());
+                }
+            );
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/user/fixture/UserV1DtoFixture.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/user/fixture/UserV1DtoFixture.java
@@ -1,0 +1,28 @@
+package com.loopers.interfaces.api.user.fixture;
+
+import static org.instancio.Select.field;
+
+import com.loopers.interfaces.api.user.UserV1Dto;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import org.instancio.Instancio;
+import org.instancio.InstancioApi;
+
+public class UserV1DtoFixture {
+
+    public static class SignUpRequest {
+        public static InstancioApi<UserV1Dto.SignUpRequest> complete() {
+            return Instancio.of(UserV1Dto.SignUpRequest.class)
+                .generate(field(UserV1Dto.SignUpRequest::userId), gen -> gen.string()
+                    .length(5, 10)
+                    .alphaNumeric()
+                )
+                .generate(field(UserV1Dto.SignUpRequest::email), gen -> gen.net().email())
+                .generate(field(UserV1Dto.SignUpRequest::birth), gen -> gen.temporal()
+                    .localDate()
+                    .range(LocalDate.of(1950, 1, 1), LocalDate.of(2005, 12, 31))
+                    .as(date -> date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
+                );
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,4 @@
-rootProject.name = "loopers-java-spring-template"
+rootProject.name = "loopers-ecommerce"
 
 include(
     ":apps:commerce-api",


### PR DESCRIPTION
## 📌 Summary
<!--
    어떤 기능/이슈를 해결했는지 요약해주세요.
-->
- 회원 가입, 로그인 및 포인트 시스템 구현
- TDD 방식으로 개발하며 단위/통합/E2E 테스트 작성

### 이슈


## 💬 Review Points
<!--
    리뷰어가 더 효과적인 리뷰를 할 수 있도록 도와주는 부분입니다.
    (1) 리뷰어가 중점적으로 봐줬으면 하는 부분
    (2) 고민했던 설계 포인트나 로직
    (3) 리뷰어가 확인해줬으면 하는 테스트 케이스나 예외 상황
    (4) 기타 리뷰어가 참고해야 할 사항
-->

## 도메인 설계 및 아키텍처

#### 회원 도메인 Validator 설계:
회원 가입 시 필요한 정책들을 회원 도메인 영역 내에서 관리하기 위해 private static class로 Validator를 구성했습니다. 이렇게 설계한 이유는 회원가입 정책들을 도메인 내부에서 캡슐화하여 응집도를 높이고, 외부에서 직접 접근하지 못하도록 하려는 의도였습니다. 이런 내부 클래스를 활용한 도메인 정책 관리 방식에 대한 의견을 듣고 싶습니다.
- [User](https://github.com/donghun0508/loopers-ecommerce/blob/base-week-1/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java)

#### 에러 처리 전략 변경:
기존 실무 경험에서 요구사항 변경으로 에러 메시지가 자주 바뀌면서 에러 케이스별로 클래스를 만들었는데, 관리포인트가 너무 커지고 중복 클래스 생성 문제가 있었습니다. 멘토링을 통해 에러 케이스가 아닌 에러 유형별로 추상화해서 관리하는 방식을 알게 되어 이번에 적용해봤습니다. 현재 회원 도메인에서 나눈 에러 유형 수준이 적절한지, 너무 추상화되었거나 부족한 부분은 없는지 의견을 듣고 싶습니다.
- [Error Package](https://github.com/donghun0508/loopers-ecommerce/tree/base-week-1/apps/commerce-api/src/main/java/com/loopers/support/error)

## API 설계 및 인터페이스

#### 메서드 시그니처 파라미터 설계 고민:
메서드 시그니처 설계는 곧 인터페이스 설계처럼 중요한 부분이라고 생각합니다. 그 이유는 변경 시 사용하는 모든 곳에 영향을 주기 때문에 신중하게 설계하는 것이 좋다고 생각했습니다. 현재 포인트 충전 기능에서 UserFacade의 chargePoint 메서드에서 userId와 amount만 받도록 했는데, 파라미터가 늘어나면 DTO로 변경해야 하는 상황이 올 경우를 생각해봤습니다. 이때 파라미터 성격을 구분해보면 "조회용 데이터(userId)"와 "액션 처리용 데이터(amount)"로 나뉠 것 같습니다. 회원가입의 경우 signUp 메서드에서 Command 객체를 도메인 레벨에 구성했는데, 포인트 충전도 ChargeCommand를 추가했다면 (userId, ChargeCommand) 구조가 될 텐데, 이런 식으로 조회용 데이터와 Command를 분리하는 방식이 적절한지 궁금합니다. 다만 ChargeCommand 내에 userId를 포함시키는 것은 맞지 않을 것 같아서, 이런 상황에서 어떤 식으로 파라미터를 설계하는 것이 좋을지 의견을 듣고 싶습니다.
- [UserFacade](https://github.com/donghun0508/loopers-ecommerce/blob/base-week-1/apps/commerce-api/src/main/java/com/loopers/application/user/UserFacade.java)
- [UserCommand](https://github.com/donghun0508/loopers-ecommerce/blob/base-week-1/apps/commerce-api/src/main/java/com/loopers/domain/user/UserCommand.java)

## 테스트 전략 및 구조

#### Fixture를 사용한 랜덤 테스트 데이터 생성:
테스트 데이터 생성을 위해 Object Mother 패턴으로 Fixture를 구성하여 매번 랜덤한 값으로 테스트를 진행했습니다. 예를 들어 회원 생성 시 이메일, userId 등을 랜덤하게 생성해서 테스트마다 다른 데이터로 검증하도록 구성했는데, 이런 접근 방식에 대해 어떻게 생각하시는지 궁금합니다. 개선할 부분이 있다면 조언해 주시면 감사하겠습니다.
- [UserTest.java](https://github.com/donghun0508/loopers-ecommerce/blob/base-week-1/apps/commerce-api/src/test/java/com/loopers/domain/user/UserTest.java)
- [UserCommandFixture.java](https://github.com/donghun0508/loopers-ecommerce/blob/base-week-1/apps/commerce-api/src/test/java/com/loopers/domain/user/fixture/UserCommandFixture.java)

#### 테스트 코드 작성 스타일:
Arrange/Act/Assert 구조로 테스트를 작성하고 있습니다. 테스트 작성 시 코드를 복사 붙여넣기로 만드는 경우가 종종 있는데, 일반적인 테스트 작성 흐름인지가 궁금합니다.
또한 공통된 부분을 메서드로 추출해서 재사용성을 높이면 테스트 작성이 더 효율적일 것 같다는 생각이 들었습니다. 예를 들어 회원가입 전처리나 회원 데이터 검증 같은 반복되는 로직을 별도 메서드로 분리하면 효율적으로 처리할 수 있을 것 같았습니다.
이렇게 진행하면서 각각 장단점이 있을 것 같은데, 테스트 코드 내 비슷한 코드를 중복해서 처리할 경우 테스트 간 독립성을 보장할 수 있지만, 메서드 추출 방식은 재사용성과 유지보수성이 좋을 것 같습니다. 실제로 메서드로 추출했을 때 회원 속성이 추가되면 해당 메서드만 수정하면 되는 장점이 있었습니다.
어떤 방식이 더 나은 접근법인지, 또는 상황에 따라 다르게 적용해야 하는지 의견을 듣고 싶습니다.
- [UserV1ApiE2ETest](https://github.com/donghun0508/loopers-ecommerce/blob/base-week-1/apps/commerce-api/src/test/java/com/loopers/interfaces/api/user/UserV1ApiE2ETest.java)

## ✅ Checklist
<!--
    해당 작업이 완료되었는지 확인하기 위한 체크리스트입니다.
    리뷰어가 확인해야 할 사항을 포함합니다.
    계획중이나 아직 완료되지 않은 작업 또한 `TODO -` 로 작성해주세요.  

    ex.
    - [o] 테스트 코드 포함
    - [o] 불필요한 코드 제거
    - [x] 미비한 테스트 코드 포함
-->
    - [o] 요구사항에 기재된 기능 구현
    - [o] 테스트 코드 포함
    - [o] 불필요한 코드 제거
    - [x] 미비한 테스트 코드 포함
    - [x] 테스트 대역(Mock/Stub) 사용법 개선 필요
    - [x] git commit 단위 및 메시지 개선 필요
    